### PR TITLE
Don't interrupt a healer when an enemy target dies

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -3781,13 +3781,14 @@ void PlayerbotAI::UpdateAI(const uint32 /*p_time*/)
     if (!m_findNPC.empty())
         findNearbyCreature();
 
-    // if we are casting a spell then interrupt it
+    // if we are casting a spell then interrupt it, unless we're a healer
     // make sure any actions that cast a spell set a proper m_ignoreAIUpdatesUntilTime!
     Spell* const pSpell = GetCurrentSpell();
     if (pSpell && !(pSpell->IsChannelActive() || pSpell->IsAutoRepeat()))
     {
         // DEBUG_LOG("spell (%s) is being interrupted",pSpell->m_spellInfo->SpellName[0]);
-        InterruptCurrentCastingSpell();
+        if (!(GetCombatOrder() & ORDERS_HEAL))
+            InterruptCurrentCastingSpell();
         return;
     }
 


### PR DESCRIPTION
This fixes an issue where a healer's spellcast would be interrupted whenever an enemy target died.