### PR TITLE
Mages should buff everyone with Arcane Intellect

### DIFF
--- a/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
+++ b/src/game/PlayerBot/AI/PlayerbotMageAI.cpp
@@ -441,7 +441,7 @@ void PlayerbotMageAI::DoNonCombatActions()
         if (Buff(&PlayerbotMageAI::BuffHelper, ARCANE_BRILLIANCE) & RETURN_CONTINUE)
             return;
     }
-    else if (Buff(&PlayerbotMageAI::BuffHelper, ARCANE_INTELLECT, JOB_MANAONLY) & RETURN_CONTINUE)
+    else if (Buff(&PlayerbotMageAI::BuffHelper, ARCANE_INTELLECT) & RETURN_CONTINUE)
         return;
 
     Item* gem = FindManaGem();


### PR DESCRIPTION
This fixes an issue where mage bots refused to buff anyone (including themselves) with Arcane Intellect.