### PR TITLE
Don't loot in combat

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -3848,7 +3848,9 @@ void PlayerbotAI::UpdateAI(const uint32 /*p_time*/)
                 TellMaster("I was still waiting OOC but I just got out of combat...");
             ClearCombatOrder(ORDERS_TEMP);
         }
-        SetState(BOTSTATE_LOOTING);
+        //Give a hoot, don't combat loot
+        if (!(IsInCombat()))
+            SetState(BOTSTATE_LOOTING);
         m_attackerInfo.clear();
         if (HasCollectFlag(COLLECT_FLAG_COMBAT))
             m_lootTargets.unique();
@@ -3877,7 +3879,7 @@ void PlayerbotAI::UpdateAI(const uint32 /*p_time*/)
         return MovementReset();
 
     // do class specific non combat actions
-    if (GetClassAI() && !m_bot->IsMounted() && !IsRegenerating())
+    if (GetClassAI() && !m_bot->IsMounted() && !IsRegenerating() && !IsInCombat())
     {
         GetClassAI()->DoNonCombatActions();
 


### PR DESCRIPTION
Prevent bots from charging in and trying to loot whenever an enemy target dies.