### PR TITLE
Increase skill gain rate

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -5074,7 +5074,7 @@ void Player::UpdateCombatSkills(Unit* pVictim, WeaponAttackType attType, bool de
     if (skilldif <= 0)
         return;
 
-    float chance = float(3 * lvldif * skilldif) / plevel;
+    float chance = float(3 * lvldif * skilldif) / log2(plevel + 1);
     if (!defence)
         chance *= 0.1f * GetStat(STAT_INTELLECT);
 


### PR DESCRIPTION
The higher a player's level, the lower the chance we'll get into the `UpdateSkill()` function to grant a skill point (which doesn't even guarantee a skillup), regardless of the current skill deficit. This change reduces the impact of a player's level on that skillup chance.